### PR TITLE
fix: read port from confg file

### DIFF
--- a/grafana.sh
+++ b/grafana.sh
@@ -166,7 +166,12 @@ set_env_DB() {
         DB_TLS="false"
     elif [[ "${DB_TYPE}" == "postgres" ]]
     then
-        DB_PORT="5432"
+        if ! DB_PORT=$(jq -r -e '.credentials.port' <<<"${db}")
+    	then
+   			DB_PORT=$(jq -r -e '.credentials.uri |
+           		split("://")[1] | split(":")[1] |
+           		split("@")[1] | split(":")[1] | split("/")[0]' <<<"${db}") || DB_PORT='' 
+   		fi
         uri="${uri}:${DB_PORT}"
         DB_TLS="disable"
     fi


### PR DESCRIPTION
There is an issue while connecting the postgres database service in cloud foundry as it is not listening to port 5432 and in the script the port was set to 5432, so setting the port dynamically by reading it from the config file.